### PR TITLE
Fix scrolling to SkillsSection when switching tabs

### DIFF
--- a/src/SkillsSection.jsx
+++ b/src/SkillsSection.jsx
@@ -29,8 +29,12 @@ const SkillsSection = () => {
 
     if (tab) {
       setActiveTab(tab);
+      // Scroll to the section when tab changes
+      document
+        .getElementById("skills-section")
+        ?.scrollIntoView({ behavior: "smooth" });
     } else {
-      setActiveTab("skills"); // Default tab
+      setActiveTab("skills");
     }
   }, [location]);
 


### PR DESCRIPTION
Added smooth scrolling to the SkillsSection when a tab is selected, ensuring the page navigates to the section properly.